### PR TITLE
feat: pulling authentication logic into connect function

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -20,15 +20,10 @@ var installCmd = &cobra.Command{
 		ref := args[0]
 		ctx := context.Background()
 		fmt.Println("🧰 Pulling", ref)
-		repo, err := oci.ConnectToRegistry(ref)
-		if err != nil {
-			fmt.Println("Error connecting to registry:", err)
-			os.Exit(1)
-		}
 		client := &oci.OrasClientImpl{}
-		workingDir, err := oci.Pull(ctx, client, repo, ref, "./.universal-packages")
+		workingDir, err := oci.Pull(ctx, client, ref, "./.universal-packages")
 		if err != nil {
-			log.Fatal(err)
+			log.Fatalf("could not pull OCI artefact %q: %v", ref, err)
 		}
 
 		packageName := cmd.Flag("package-name").Value.String()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ import (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "universal-packages",
+	Use:   "upkg",
 	Short: "A brief description of your application",
 	Long: `Universal Packages CLI is a tool to manage and install packages from OCI registries.
 It allows you to pull packages, install them, and manage dependencies across different ecosystems and platforms.`,

--- a/internal/oci/oci_test.go
+++ b/internal/oci/oci_test.go
@@ -44,12 +44,7 @@ func TestPull(t *testing.T) {
 			client := &FakeOrasClient{}
 			ctx := context.Background()
 
-			repo, err := ConnectToRegistry(testCase.ref)
-			if err != nil {
-				t.Fatalf("failed to connect to registry: %v", err)
-			}
-
-			workingDir, err := Pull(ctx, client, repo, "", "./.universal-packages")
+			workingDir, err := Pull(ctx, client, testCase.ref, "./.universal-packages")
 			if err != nil {
 				t.Fatalf("failed to pull package: %v", err)
 			}


### PR DESCRIPTION
fixes #24 

At the moment, I have opted to use `NewStoreFromDocker` but pull it into the connecToRegistry function so push and pull logic can both use the same auth logic.

So at the moment, to use private registries the user will have to do `docker login` or an equivalent. 